### PR TITLE
Resolve dramatiq and dramatiq-gevent using system executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Add `django_dramatiq` to installed apps *before* any of your custom
 apps:
 
 ``` python
+import os
+
+# django_dramatiq adds this value to append to PYTHONPATH
+BASE_DIR = os.path.dirname(__file__)
+
 INSTALLED_APPS = [
     "django_dramatiq",
 

--- a/django_dramatiq/management/commands/rundramatiq.py
+++ b/django_dramatiq/management/commands/rundramatiq.py
@@ -1,5 +1,7 @@
 import multiprocessing
 import os
+import subprocess
+import sys
 
 from django.apps import apps
 from django.conf import settings
@@ -44,7 +46,7 @@ class Command(BaseCommand):
         verbosity_args = ["-v"] * (verbosity - 1)
         tasks_modules = self.discover_tasks_modules()
         process_args = [
-            executable,
+            self._resolve_executable(executable),
             "--processes", str(processes),
             "--threads", str(threads),
 
@@ -60,7 +62,7 @@ class Command(BaseCommand):
 
         self.stdout.write(f' * Running dramatiq: "{" ".join(process_args)}"\n\n')
         os.putenv("PYTHONPATH", f"{settings.BASE_DIR}")
-        os.execvp("dramatiq", process_args)
+        os.execvp(self._resolve_executable("dramatiq"), process_args)
 
     def discover_tasks_modules(self):
         app_configs = apps.get_app_configs()
@@ -74,3 +76,9 @@ class Command(BaseCommand):
                 tasks_modules.append(module)
                 self.stdout.write(f" * Discovered tasks module: {module!r}")
         return tasks_modules
+
+    def _resolve_executable(self, exec_name):
+        bin_dir = os.path.dirname(sys.executable)
+        if bin_dir:
+            return os.path.join(bin_dir, exec_name)
+        return exec_name

--- a/tests/test_rundramatiq_command.py
+++ b/tests/test_rundramatiq_command.py
@@ -1,7 +1,11 @@
-from django.core.management import call_command
-from django_dramatiq.management.commands import rundramatiq
+import os
+import sys
+
 from io import StringIO
 from unittest.mock import patch
+
+from django.core.management import call_command
+from django_dramatiq.management.commands import rundramatiq
 
 from .settings import path_to
 
@@ -24,10 +28,15 @@ def test_rundramatiq_can_run_dramatiq(execvp_mock):
     # Then stdout should contain a message about discovered task modules
     assert "Discovered tasks module: 'tests.testapp.tasks'" in buff.getvalue()
 
+    expected_exec_path = os.path.join(
+        os.path.dirname(sys.executable),
+        'dramatiq'
+    )
+
     # And execvp should be called with the appropriate arguments
     cores = str(rundramatiq.CPU_COUNT)
-    execvp_mock.assert_called_once_with("dramatiq", [
-        "dramatiq", "--processes", cores, "--threads", cores,
+    execvp_mock.assert_called_once_with(expected_exec_path, [
+        expected_exec_path, "--processes", cores, "--threads", cores,
         "--watch", path_to().replace("/tests", ""),
         "django_dramatiq.setup",
         "tests.testapp.tasks",


### PR DESCRIPTION
This change was basically because using `dramatiq` and `dramatic-gevent` caused the `os` module to raise a `file not found` error when i ran this inside the docker container. The way i did this was using the command:
```
./venv/bin/python manage.py rundramatiq
```
Which meant that the current virtualenv is not activated but rather, the python executable is directly used. Which basically resembles the way other people and I configure this in places such as docker-compose files or supervisor configurations.
