### PR TITLE
Support Django's settings to set message encoder

### DIFF
--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -24,7 +24,7 @@ DEFAULT_SETTINGS = {
         "django_dramatiq.middleware.DbConnectionsMiddleware",
     ]
 }
-DEFAULT_TASK_ENCODER = "dramatiq.encoder.JSONEncoder"
+DEFAULT_ENCODER = "dramatiq.encoder.JSONEncoder"
 
 
 class DjangoDramatiqConfig(AppConfig):
@@ -39,7 +39,7 @@ class DjangoDramatiqConfig(AppConfig):
         middleware = [load_middleware(path) for path in broker_settings.get("MIDDLEWARE", [])]
         broker = broker_class(middleware=middleware, **broker_options)
         dramatiq.set_broker(broker)
-        dramatiq.set_encoder(type(self).select_encoder())
+        dramatiq.set_encoder(self.select_encoder())
 
     @classmethod
     def broker_settings(cls):
@@ -51,5 +51,5 @@ class DjangoDramatiqConfig(AppConfig):
 
     @classmethod
     def select_encoder(cls):
-        encoder = getattr(settings, "DRAMATIQ_TASK_ENCODER", DEFAULT_TASK_ENCODER)
+        encoder = getattr(settings, "DRAMATIQ_ENCODER", DEFAULT_ENCODER)
         return load_class(encoder)()

--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -32,7 +32,7 @@ class DjangoDramatiqConfig(AppConfig):
     verbose_name = "Django Dramatiq"
 
     def ready(self):
-        broker_settings = type(self).broker_settings()
+        broker_settings = self.broker_settings()
         broker_path = broker_settings["BROKER"]
         broker_class = load_class(broker_path)
         broker_options = broker_settings.get("OPTIONS", {})

--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -24,6 +24,7 @@ DEFAULT_SETTINGS = {
         "django_dramatiq.middleware.DbConnectionsMiddleware",
     ]
 }
+DEFAULT_TASK_ENCODER = "dramatiq.encoder.JSONEncoder"
 
 
 class DjangoDramatiqConfig(AppConfig):
@@ -38,6 +39,7 @@ class DjangoDramatiqConfig(AppConfig):
         middleware = [load_middleware(path) for path in broker_settings.get("MIDDLEWARE", [])]
         broker = broker_class(middleware=middleware, **broker_options)
         dramatiq.set_broker(broker)
+        dramatiq.set_encoder(type(self).select_encoder())
 
     @classmethod
     def broker_settings(cls):
@@ -46,3 +48,8 @@ class DjangoDramatiqConfig(AppConfig):
     @classmethod
     def tasks_database(cls):
         return getattr(settings, "DRAMATIQ_TASKS_DATABASE", "default")
+
+    @classmethod
+    def select_encoder(cls):
+        encoder = getattr(settings, "DRAMATIQ_TASK_ENCODER", DEFAULT_TASK_ENCODER)
+        return load_class(encoder)()


### PR DESCRIPTION
Hi @Bogdanp based on the https://github.com/Bogdanp/dramatiq/issues/17 I made this little contribution to make more "Djangish" your package. Now you can set a custom Encoder via Django's settings.

I hope that the naming convention that I applied be right (I thought that  the encoder is related to the broker's options but ... you may decide this.)
Thanks for your time!