### PR TITLE
configurable results backend via settings

### DIFF
--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -31,6 +31,9 @@ class DjangoDramatiqConfig(AppConfig):
     verbose_name = "Django Dramatiq"
 
     def ready(self):
+        # this line should be first, to set up global encoder before any middleware is created
+        dramatiq.set_encoder(self.select_encoder())
+
         broker_settings = self.broker_settings()
         broker_path = broker_settings["BROKER"]
         broker_class = load_class(broker_path)
@@ -39,7 +42,6 @@ class DjangoDramatiqConfig(AppConfig):
         broker = broker_class(middleware=middleware, **broker_options)
         self.load_results_backend(broker, broker_settings)
         dramatiq.set_broker(broker)
-        dramatiq.set_encoder(self.select_encoder())
 
     @classmethod
     def load_results_backend(self, broker, broker_settings):

--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -52,8 +52,8 @@ class DjangoDramatiqConfig(AppConfig):
                 middleware.backend = backend
                 break
         else:
-            result_middleware = load_class("dramatiq.results.middleware.Results")(backend)
-            broker.add_middleware(result_middleware)
+            results_middleware = load_class("dramatiq.results.middleware.Results")(backend=backend)
+            broker.add_middleware(results_middleware)
 
     @classmethod
     def broker_settings(cls):

--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -1,7 +1,7 @@
 import dramatiq
 from django.apps import AppConfig
 from django.conf import settings
-
+from dramatiq.results import Results
 from .utils import load_class, load_middleware
 
 DEFAULT_BROKER = "dramatiq.brokers.rabbitmq.RabbitmqBroker"
@@ -37,8 +37,23 @@ class DjangoDramatiqConfig(AppConfig):
         broker_options = broker_settings.get("OPTIONS", {})
         middleware = [load_middleware(path) for path in broker_settings.get("MIDDLEWARE", [])]
         broker = broker_class(middleware=middleware, **broker_options)
+        self.load_results_backend(broker, broker_settings)
         dramatiq.set_broker(broker)
         dramatiq.set_encoder(self.select_encoder())
+
+    @classmethod
+    def load_results_backend(self, broker, broker_settings):
+        backend_settings = broker_settings.get("RESULTS_BACKEND", "dramatiq.results.backends.StubBackend")
+        backend_class = load_class(backend_settings)
+        backend_options = broker_settings.get("RESULTS_BACKEND_OPTIONS", {})
+        backend = backend_class(**backend_options)
+        for middleware in broker.middleware:
+            if isinstance(middleware, Results):
+                middleware.backend = backend
+                break
+        else:
+            result_middleware = load_class("dramatiq.results.middleware.Results")(backend)
+            broker.add_middleware(result_middleware)
 
     @classmethod
     def broker_settings(cls):

--- a/django_dramatiq/utils.py
+++ b/django_dramatiq/utils.py
@@ -2,8 +2,8 @@ import importlib
 
 
 def load_class(path):
+    module_path, _, class_name = path.rpartition(".")
     try:
-        module_path, _, class_name = path.rpartition(".")
         module = importlib.import_module(module_path)
         return getattr(module, class_name)
     except AttributeError:


### PR DESCRIPTION
now it's possible to configure results backend via broker settings

example:

```
DRAMATIQ_BROKER = {
    'BROKER': 'dramatiq.brokers.redis.RedisBroker',
    'OPTIONS': {
        'url': 'redis://localhost:6379',
    },
    'RESULTS_BACKEND': 'dramatiq.results.backends.RedisBackend',
    'RESULTS_BACKEND_OPTIONS': {
        'url': 'redis://localhost:6379',
    },
    'MIDDLEWARE': [
        'dramatiq.middleware.AgeLimit',
        'dramatiq.middleware.TimeLimit',
        'dramatiq.middleware.Callbacks',
        'dramatiq.middleware.Retries',
        'dramatiq.results.middleware.Results',
        'django_dramatiq.middleware.AdminMiddleware',
        'django_dramatiq.middleware.DbConnectionsMiddleware',
    ]
}
```