### PR TITLE
Add more options to django command wrapper

### DIFF
--- a/django_dramatiq/management/commands/rundramatiq.py
+++ b/django_dramatiq/management/commands/rundramatiq.py
@@ -53,8 +53,25 @@ class Command(BaseCommand):
             type=str,
             help="The import path (default: .).",
         )
+        parser.add_argument(
+            "--queues", "-Q",
+            nargs="*",
+            type=str,
+            help="listen to a subset of queues (default: all queues)",
+        )
+        parser.add_argument(
+            "--pid-file",
+            type=str,
+            help="write the PID of the master process to a file (default: no pid file)",
+        )
+        parser.add_argument(
+            "--log-file",
+            type=str,
+            help="write all logs to a file (default: sys.stderr)",
+        )
 
-    def handle(self, use_watcher, use_polling_watcher, use_gevent, path, processes, threads, verbosity, **options):
+    def handle(self, use_watcher, use_polling_watcher, use_gevent, path, processes, threads, verbosity, queues,
+               pid_file, log_file, **options):
         executable_name = "dramatiq-gevent" if use_gevent else "dramatiq"
         executable_path = self._resolve_executable(executable_name)
         watch_args = ["--watch", "."] if use_watcher else []
@@ -78,6 +95,15 @@ class Command(BaseCommand):
             # django_dramatiq.tasks app1.tasks app2.tasks ...
             *tasks_modules,
         ]
+
+        if queues:
+            process_args.extend(["--queues", *queues])
+
+        if pid_file:
+            process_args.extend(["--pid-file", pid_file])
+
+        if log_file:
+            process_args.extend(["--log-file", log_file])
 
         self.stdout.write(' * Running dramatiq: "%s"\n\n' % " ".join(process_args))
         os.execvp(executable_path, process_args)

--- a/tests/test_rundramatiq_command.py
+++ b/tests/test_rundramatiq_command.py
@@ -68,3 +68,81 @@ def test_rundramatiq_can_run_dramatiq_with_polling(execvp_mock):
         "django_dramatiq.tasks",
         "tests.testapp.tasks",
     ])
+
+
+@patch("os.execvp")
+def test_rundramatiq_can_run_dramatiq_with_only_some_queues(execvp_mock):
+    # Given an output buffer
+    buff = StringIO()
+
+    # When I call the rundramatiq command with --queues
+    call_command("rundramatiq", "--queues", "A B C", stdout=buff)
+
+    # Then execvp should be called with the appropriate arguments
+    cores = str(rundramatiq.CPU_COUNT)
+    expected_exec_name = "dramatiq"
+    expected_exec_path = os.path.join(
+        os.path.dirname(sys.executable),
+        expected_exec_name,
+    )
+
+    execvp_mock.assert_called_once_with(expected_exec_path, [
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        "--watch", ".",
+        "django_dramatiq.setup",
+        "django_dramatiq.tasks",
+        "tests.testapp.tasks",
+        "--queues", "A B C"
+    ])
+
+
+@patch("os.execvp")
+def test_rundramatiq_can_run_dramatiq_with_specified_pid_file(execvp_mock):
+    # Given an output buffer
+    buff = StringIO()
+
+    # When I call the rundramatiq command with --pid-file
+    call_command("rundramatiq", "--pid-file", "drama.pid", stdout=buff)
+
+    # Then execvp should be called with the appropriate arguments
+    cores = str(rundramatiq.CPU_COUNT)
+    expected_exec_name = "dramatiq"
+    expected_exec_path = os.path.join(
+        os.path.dirname(sys.executable),
+        expected_exec_name,
+    )
+
+    execvp_mock.assert_called_once_with(expected_exec_path, [
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        "--watch", ".",
+        "django_dramatiq.setup",
+        "django_dramatiq.tasks",
+        "tests.testapp.tasks",
+        "--pid-file", "drama.pid"
+    ])
+
+
+@patch("os.execvp")
+def test_rundramatiq_can_run_dramatiq_with_specified_log_file(execvp_mock):
+    # Given an output buffer
+    buff = StringIO()
+
+    # When I call the rundramatiq command with --log-file
+    call_command("rundramatiq", "--log-file", "drama.log", stdout=buff)
+
+    # Then execvp should be called with the appropriate arguments
+    cores = str(rundramatiq.CPU_COUNT)
+    expected_exec_name = "dramatiq"
+    expected_exec_path = os.path.join(
+        os.path.dirname(sys.executable),
+        expected_exec_name,
+    )
+
+    execvp_mock.assert_called_once_with(expected_exec_path, [
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        "--watch", ".",
+        "django_dramatiq.setup",
+        "django_dramatiq.tasks",
+        "tests.testapp.tasks",
+        "--log-file", "drama.log"
+    ])


### PR DESCRIPTION
This PR is intended to make the django command wrapper more similar to the original one allowing to pass more arguments:
 - `--queues`
 - `--log-file`,
 - `--pid-file`