### PR TITLE
Use update_or_create instead of custom implementation

### DIFF
--- a/django_dramatiq/models.py
+++ b/django_dramatiq/models.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.db import models, utils
+from django.db import models
 from django.utils.functional import cached_property
 from django.utils.timezone import now
 from dramatiq import Message
@@ -13,21 +13,12 @@ DATABASE_LABEL = DjangoDramatiqConfig.tasks_database()
 
 class TaskManager(models.Manager):
     def create_or_update_from_message(self, message, **extra_fields):
-        try:
-            return self.using(DATABASE_LABEL).create(
-                id=message.message_id,
-                message_data=message.encode(),
-                **extra_fields,
-            )
-
-        except (utils.OperationalError, utils.IntegrityError):
-            task = self.using(DATABASE_LABEL).get(id=message.message_id)
-            task.message_data = message.encode()
-            for name, value in extra_fields.items():
-                setattr(task, name, value)
-
-            task.save()
-            return task
+        defaults = {'message_data': message.encode()}
+        defaults.update(extra_fields)
+        obj, _ = self.using(DATABASE_LABEL).update_or_create(
+            id=message.message_id,
+            defaults=defaults)
+        return obj
 
     def delete_old_tasks(self, max_task_age):
         self.using(DATABASE_LABEL).filter(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,27 @@
+import uuid
+from unittest import mock
+
+from django_dramatiq.models import Task
+
+
+def test_task_create_or_update_from_message(transactional_db, broker, worker):
+    message = mock.Mock()
+    message_id = uuid.uuid4()
+    message.encode.return_value = b"{}"
+    message.message_id = message_id
+
+    Task.tasks.create_or_update_from_message(message)
+
+    # Created it
+    t = Task.tasks.get(pk=message.message_id)
+    message.encode.assert_called_once_with()
+    assert t.message_data == message.encode.return_value
+    message.encode.reset_mock()
+    message.encode.return_value = b'{"another_one", 12}'
+    Task.tasks.create_or_update_from_message(message)
+
+    # Updated it
+    t.refresh_from_db()
+    message.encode.assert_called_once_with()
+    assert Task.tasks.count() == 1
+    assert t.message_data == message.encode.return_value


### PR DESCRIPTION
I think we should use Django's `update_or_create`. The current implementation does not use `select_for_update` and does not wrap queries into a transaction and other corner cases that Django already handle with tested code.