### PR TITLE
Updated setup.py to include relevant information for django packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,21 @@ setup(
         "django>=1.11",
         "dramatiq>=0.18.0",
     ],
+    classifiers=[
+        'Environment :: Web Environment',
+        'Operating System :: OS Independent',
+        'Framework :: Django',
+        'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
     extras_require={
         "dev": [
             "bumpversion",


### PR DESCRIPTION
Django Packages uses setup.py to determine whether a package supports Python 3.

[django_dramatiq's django packages entry](https://djangopackages.org/packages/p/django_dramatiq/) currently does not show that Python 3 is supported.

This pull request simply updates setup.py to show support for Python 2.7+ & 3.4+ and django 1.11+