### PR TITLE
Fixed not able to use redis as broker with django_dramatiq

### DIFF
--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -71,7 +71,11 @@ class DjangoDramatiqConfig(AppConfig):
         if result_backend is not None:
             middleware.append(results_middleware)
 
-        broker = broker_class(middleware=middleware, **broker_options)
+        if broker_path == "dramatiq.brokers.redis.RedisBroker":
+            broker = broker_class(**broker_options)
+        else:
+            broker = broker_class(middleware=middleware, **broker_options)
+
         dramatiq.set_broker(broker)
 
     @property


### PR DESCRIPTION
This is PR for fixing the configuration issue when using redis as broker. 

```python
File "*****************/python3.7/site-packages/django_dramatiq/apps.py", line 107, in <module>
DjangoDramatiqConfig.initialize()
File "*****************/python3.7/site-packages/django_dramatiq/apps.py", line 74, in initialize
    broker = broker_class(middleware=middleware, **broker_options)
File "*****************/python3.7/site-packages/dramatiq/results/backends/redis.py", line 48, in __init__
    self.client = client or redis.StrictRedis(**parameters)
TypeError: __init__() got an unexpected keyword argument 'middleware'
```

This PR will fixes this issus. 