### PR TITLE
Add more Task filters to admin interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Tasks in the admin can now be filtered by ``queue_name`` and ``actor_name``. ([@jcass77])
+
 ## [0.7.1] - 2019-06-06
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-- Tasks in the admin can now be filtered by ``queue_name`` and ``actor_name``. ([@jcass77])
+- Tasks in the admin can now be filtered by ``created_at``, ``queue_name``,
+  and ``actor_name``. ([@jcass77])
 
 ## [0.7.1] - 2019-06-06
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@ This file lists the contributors to the `django_dramatiq` project.
 | [@CapedHero](https://github.com/CapedHero)     | Maciej Wrześniewski |
 | [@denizdogan](https://github.com/denizdogan)   | Deniz Dogan         |
 | [@OmenApps](https://github.com/OmenApps)       | OmenApps            |
+| [@jcass77](https://github.com/jcass77)         | John Cass           |

--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -2,33 +2,38 @@ import abc
 import json
 from datetime import datetime
 
-import dramatiq
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.utils import timezone
 from django.utils.safestring import mark_safe
+from dramatiq import Message
 
 from .models import Task
 
 
 class TaskFilter(abc.ABC, SimpleListFilter):
-
-    @property
-    def declared_broker_objects(self):
-        broker = dramatiq.get_broker()
-        return {
-            "actor_name": broker.get_declared_actors(),
-            "queue_name": broker.get_declared_queues().union(broker.get_declared_delay_queues())
-        }
-
     def lookups(self, request, model_admin):
-        lookup_choices = self.declared_broker_objects[self.parameter_name]
-        return [(name, "{} (slow)".format(name)) for name in lookup_choices]
-    
+        lookup_choices = set()
+
+        messages = (
+            Message.decode(bytes(encoded_message))
+            for encoded_message in model_admin.model.tasks.values_list(
+                "message_data", flat=True
+            )
+        )
+
+        for message in messages:
+            choice = getattr(message, self.parameter_name)
+            lookup_choices.add((choice, "{} (slow)".format(choice)))
+
+        return sorted(lookup_choices)
+
     def queryset(self, request, queryset):
         if self.value():
             filter_ids = (
-                str(task.id) for task in queryset if getattr(task.message, self.parameter_name) == self.value()
+                str(task.id)
+                for task in queryset
+                if getattr(task.message, self.parameter_name) == self.value()
             )
             return queryset.filter(id__in=filter_ids)
 
@@ -49,8 +54,16 @@ class ActorNameFilter(TaskFilter):
 class TaskAdmin(admin.ModelAdmin):
     exclude = ("message_data",)
     readonly_fields = ("message_details", "traceback", "status")
-    list_display = ("__str__", "status", "eta", "created_at", "updated_at", "queue_name", "actor_name")
-    list_filter = ("status", QueueNameFilter, ActorNameFilter)
+    list_display = (
+        "__str__",
+        "status",
+        "eta",
+        "created_at",
+        "updated_at",
+        "queue_name",
+        "actor_name",
+    )
+    list_filter = ("status", "created_at", QueueNameFilter, ActorNameFilter)
 
     def queue_name(self, instance):
         return instance.message.queue_name
@@ -59,7 +72,10 @@ class TaskAdmin(admin.ModelAdmin):
         return instance.message.actor_name
 
     def eta(self, instance):
-        timestamp = instance.message.options.get("eta", instance.message.message_timestamp) / 1000
+        timestamp = (
+            instance.message.options.get("eta", instance.message.message_timestamp)
+            / 1_000
+        )
         return timezone.make_aware(datetime.utcfromtimestamp(timestamp))
 
     def message_details(self, instance):

--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -73,8 +73,7 @@ class TaskAdmin(admin.ModelAdmin):
 
     def eta(self, instance):
         timestamp = (
-            instance.message.options.get("eta", instance.message.message_timestamp)
-            / 1_000
+            instance.message.options.get("eta", instance.message.message_timestamp) / 1000
         )
         return timezone.make_aware(datetime.utcfromtimestamp(timestamp))
 

--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -31,7 +31,7 @@ class TaskFilter(abc.ABC, SimpleListFilter):
     def queryset(self, request, queryset):
         if self.value():
             filter_ids = (
-                str(task.id)
+                task.id
                 for task in queryset
                 if getattr(task.message, self.parameter_name) == self.value()
             )

--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -1,11 +1,48 @@
+import abc
 import json
 from datetime import datetime
 
+import dramatiq
 from django.contrib import admin
+from django.contrib.admin import SimpleListFilter
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 
 from .models import Task
+
+
+class TaskFilter(abc.ABC, SimpleListFilter):
+
+    @property
+    def declared_broker_objects(self):
+        broker = dramatiq.get_broker()
+        return {
+            "actor_name": broker.get_declared_actors(),
+            "queue_name": broker.get_declared_queues().union(broker.get_declared_delay_queues())
+        }
+
+    def lookups(self, request, model_admin):
+        lookup_choices = self.declared_broker_objects[self.parameter_name]
+        return [(name, "{} (slow)".format(name)) for name in lookup_choices]
+    
+    def queryset(self, request, queryset):
+        if self.value():
+            filter_ids = (
+                str(task.id) for task in queryset if getattr(task.message, self.parameter_name) == self.value()
+            )
+            return queryset.filter(id__in=filter_ids)
+
+        return queryset
+
+
+class QueueNameFilter(TaskFilter):
+    title = "queue_name"
+    parameter_name = "queue_name"
+
+
+class ActorNameFilter(TaskFilter):
+    title = "actor_name"
+    parameter_name = "actor_name"
 
 
 @admin.register(Task)
@@ -13,7 +50,7 @@ class TaskAdmin(admin.ModelAdmin):
     exclude = ("message_data",)
     readonly_fields = ("message_details", "traceback", "status")
     list_display = ("__str__", "status", "eta", "created_at", "updated_at", "queue_name", "actor_name")
-    list_filter = ("status",)
+    list_filter = ("status", QueueNameFilter, ActorNameFilter)
 
     def queue_name(self, instance):
         return instance.message.queue_name


### PR DESCRIPTION
It can be quite difficult to find specific tasks using the admin interface (especially if you have a large number of actors running on a regular basis).

This PR adds filters for the `queue_name`, `actor_name` and `created_at` fields.

I initially tried to get the lookup choices by interrogating the broker using `broker.get_declared_actors()`, `broker.get_declared_queues()` and `broker.get_declared_delay_queues()`, but it seams that those methods only return values for actors and queues that have been declared as part of the current Dramatiq session?

The only alternative that I could think of was to pre-scan the data to produce the list of available choices, which is probably not terribly efficient :(