### PR TITLE
Align output of 'ETA' column with USE_TZ config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `rundramatiq` now discovers task packages.  ([@AceFire6], [#46])
 - Tasks in the admin can now be filtered by ``queue_name`` and
   ``actor_name``. ([@jcass77], [#50])
+- The 'ETA' column for Tasks in the admin now checks the Django `USE_TZ` configuration setting to ensure that dates
+  are displayed using the same timezone as the Django standard columns.
 
 [@AceFire6]: https://github.com/AceFire6
 [#46]: https://github.com/Bogdanp/django_dramatiq/pull/46

--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -76,12 +76,10 @@ class TaskAdmin(admin.ModelAdmin):
         timestamp = (
             instance.message.options.get("eta", instance.message.message_timestamp) / 1000
         )
-        if settings.USE_TZ:
-            # Django expects a timezone-aware datetime
-            return datetime.fromtimestamp(timestamp, timezone.utc)
-        else:
-            # Django expects a naive datetime in localtime
-            return datetime.fromtimestamp(timestamp)
+
+        # Django expects a timezone-aware datetime if USE_TZ is True, and a naive datetime in localtime otherwise.
+        tz = timezone.utc if settings.USE_TZ else None
+        return datetime.fromtimestamp(timestamp, tz=tz)
 
     def message_details(self, instance):
         message_details = json.dumps(instance.message._asdict(), indent=4)

--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -2,6 +2,7 @@ import abc
 import json
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.utils import timezone
@@ -75,7 +76,12 @@ class TaskAdmin(admin.ModelAdmin):
         timestamp = (
             instance.message.options.get("eta", instance.message.message_timestamp) / 1000
         )
-        return timezone.make_aware(datetime.utcfromtimestamp(timestamp))
+        if settings.USE_TZ:
+            # Django expects a timezone-aware datetime
+            return datetime.fromtimestamp(timestamp, timezone.utc)
+        else:
+            # Django expects a naive datetime in localtime
+            return datetime.fromtimestamp(timestamp)
 
     def message_details(self, instance):
         message_details = json.dumps(instance.message._asdict(), indent=4)


### PR DESCRIPTION
The timezone used to render the 'ETA' column in the Task admin does not appear to correspond with that of the `created_at` and `updated_at` `DateTimeField` fields. This results in different timezones being used to render date-based columns in the same row, which can be quite confusing.

My understanding is that the [USE_TZ](https://docs.djangoproject.com/en/dev/ref/settings/#use-tz) setting should be used to configure how Django stores and deals with timezone information.

Since the Task admin interface generates the 'ETA' column dynamically based on the message's (UTC-based) timestamp, we should probably also consider  the value of the `USE_TZ` setting to ensure that timezone information is applied consistently for all columns in the relevant admin interface.