### PR TITLE
Update rundramatiq.py

### DIFF
--- a/django_dramatiq/management/commands/rundramatiq.py
+++ b/django_dramatiq/management/commands/rundramatiq.py
@@ -119,23 +119,23 @@ class Command(BaseCommand):
         for conf in app_configs:
             module = conf.name + ".tasks"
             
-
             if module in ignored_modules:
                 self.stdout.write(" * Ignored tasks module: %r" % module)
-            else:
-                imported_module = importlib.import_module(module)
-                if not self._is_package(imported_module):
-                    self.stdout.write(" * Discovered tasks module: %r" % module)
-                    tasks_modules.append(module)
-                else:
-                    submodules = self._get_submodules(imported_module)
+                continue
 
-                    for submodule in submodules:
-                        if submodule in ignored_modules:
-                            self.stdout.write(" * Ignored tasks module: %r" % submodule)
-                        else:
-                            self.stdout.write(" * Discovered tasks module: %r" % submodule)
-                            tasks_modules.append(submodule)
+            imported_module = importlib.import_module(module)
+            if not self._is_package(imported_module):
+                self.stdout.write(" * Discovered tasks module: %r" % module)
+                tasks_modules.append(module)
+            else:
+                submodules = self._get_submodules(imported_module)
+
+                for submodule in submodules:
+                    if submodule in ignored_modules:
+                        self.stdout.write(" * Ignored tasks module: %r" % submodule)
+                    else:
+                        self.stdout.write(" * Discovered tasks module: %r" % submodule)
+                        tasks_modules.append(submodule)
 
         return tasks_modules
 

--- a/django_dramatiq/management/commands/rundramatiq.py
+++ b/django_dramatiq/management/commands/rundramatiq.py
@@ -118,22 +118,24 @@ class Command(BaseCommand):
 
         for conf in app_configs:
             module = conf.name + ".tasks"
-            imported_module = importlib.import_module(module)
+            
 
             if module in ignored_modules:
                 self.stdout.write(" * Ignored tasks module: %r" % module)
-            elif not self._is_package(imported_module):
-                self.stdout.write(" * Discovered tasks module: %r" % module)
-                tasks_modules.append(module)
             else:
-                submodules = self._get_submodules(imported_module)
+                imported_module = importlib.import_module(module)
+                if not self._is_package(imported_module):
+                    self.stdout.write(" * Discovered tasks module: %r" % module)
+                    tasks_modules.append(module)
+                else:
+                    submodules = self._get_submodules(imported_module)
 
-                for submodule in submodules:
-                    if submodule in ignored_modules:
-                        self.stdout.write(" * Ignored tasks module: %r" % submodule)
-                    else:
-                        self.stdout.write(" * Discovered tasks module: %r" % submodule)
-                        tasks_modules.append(submodule)
+                    for submodule in submodules:
+                        if submodule in ignored_modules:
+                            self.stdout.write(" * Ignored tasks module: %r" % submodule)
+                        else:
+                            self.stdout.write(" * Discovered tasks module: %r" % submodule)
+                            tasks_modules.append(submodule)
 
         return tasks_modules
 


### PR DESCRIPTION
This prevents ignored modules (specified in DRAMATIQ_IGNORED_MODULES) from being loaded.

My case was with django_slack repo whose tasks.py require celery. Even though I put it in DRAMATIQ_IGNORED_MODULES, celery is still required

