### PR TITLE
Skipped tasks support

### DIFF
--- a/django_dramatiq/models.py
+++ b/django_dramatiq/models.py
@@ -34,12 +34,14 @@ class Task(models.Model):
     STATUS_RUNNING = "running"
     STATUS_FAILED = "failed"
     STATUS_DONE = "done"
+    STATUS_SKIPPED = "skipped"
     STATUSES = [
         (STATUS_ENQUEUED, "Enqueued"),
         (STATUS_DELAYED, "Delayed"),
         (STATUS_RUNNING, "Running"),
         (STATUS_FAILED, "Failed"),
         (STATUS_DONE, "Done"),
+        (STATUS_SKIPPED, "Skipped"),
     ]
 
     id = models.UUIDField(primary_key=True, editable=False)


### PR DESCRIPTION
Support for messages that are skipped by SkipMessage exception.
Without this skipped messages got stuck in Enqueued state.
In my case i have stumbled upon this with periodiq using SkipMessage for preventing tasks being executed several times when task schedule is every small period of time (1-2 minutes) and task execution time is more than scheduling period in some cases.