### PR TITLE
rundramatiq: handle fork-functions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ This file lists the contributors to the `django_dramatiq` project.
 | [@jcass77](https://github.com/jcass77)                                 | John Cass           |
 | [@AceFire6](https://github.com/AceFire6)                               | Jethro Muller       |
 | [@OrazioPirataDelloSpazio](https://github.com/OrazioPirataDelloSpazio) | Lorenzo             |
+| [@timdrijvers](https://github.com/timdrijvers)                         | Tim Drijvers        |


### PR DESCRIPTION
Add support for handling fork-functions. I see two ways to handle this, either via the settings or cli options. Where the first option wouldn't be able to handle different fork functions per running Dramatiq instance.