### PR TITLE
Use django's existing import-from-string util

### DIFF
--- a/django_dramatiq/utils.py
+++ b/django_dramatiq/utils.py
@@ -1,18 +1,7 @@
-import importlib
-
-
-def load_class(path):
-    try:
-        module_path, _, class_name = path.rpartition(".")
-        module = importlib.import_module(module_path)
-        return getattr(module, class_name)
-    except AttributeError:
-        raise ImportError("Module '%s' doesn't have a class named '%s'." % (
-            module_path, class_name,
-        ))
+from django.utils.module_loading import import_string
 
 
 def load_middleware(path_or_obj):
     if isinstance(path_or_obj, str):
-        return load_class(path_or_obj)()
+        return import_string(path_or_obj)()
     return path_or_obj


### PR DESCRIPTION
This PR replaces `utils.load_class` with Django's `django.utils.module_loading.import_string`.

Since this app is a Django integration, there's no reason to re-create functions already provided by Django.