### PR TITLE
Remove pika's connection deprecated arguement

### DIFF
--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -15,7 +15,7 @@ DEFAULT_BROKER_SETTINGS = {
     "OPTIONS": {
         "host": "127.0.0.1",
         "port": 5672,
-        "heartbeat_interval": 0,
+        "heartbeat": 0,
         "connection_attempts": 5,
     },
     "MIDDLEWARE": [


### PR DESCRIPTION
ref: https://github.com/pika/pika/blob/3f1a56f56595dc7b933aca2998c6198e8ee9dcb9/CHANGELOG.rst#100-2019-03-26

Or dramatiq is compatible with specific `pika` version?