### PR TITLE
Fix PyPI package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can find an example application built with django_dramatiq [here][example].
 
 ## Installation
 
-    pip install django_dramatiq
+    pip install django-dramatiq
 
 Add `django_dramatiq` to installed apps *before* any of your custom
 apps:


### PR DESCRIPTION
`django_dramatiq` works with pip and `poetry add` but not `poetry remove`, so I figured we might as well use the name as it appears on PyPI.