### PR TITLE
Run tests on supported Python and Django versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 sudo: false
 python:
-  - "3.5"
   - "3.6"
-  - "3.6-dev"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
+  - "3.9"
   - "nightly"
 matrix:
   include:
@@ -13,8 +13,6 @@ matrix:
     - python: 3.6
       env: TOXENV=migrations
   allow_failures:
-    - python: "3.6-dev"
-    - python: "3.7-dev"
     - python: "nightly"
 install:
   - pip install -U tox-travis

--- a/django_dramatiq/__init__.py
+++ b/django_dramatiq/__init__.py
@@ -1,3 +1,6 @@
+import django
+
 __version__ = "0.10.0"
 
-default_app_config = "django_dramatiq.apps.DjangoDramatiqConfig"
+if django.VERSION < (3, 2):
+    default_app_config = "django_dramatiq.apps.DjangoDramatiqConfig"

--- a/setup.py
+++ b/setup.py
@@ -30,21 +30,21 @@ setup(
         "django_dramatiq.migrations",
     ],
     install_requires=[
-        "django>=1.11",
+        "django>=2.2",
         "dramatiq>=0.18.0",
     ],
     classifiers=[
         "Environment :: Web Environment",
         "Operating System :: OS Independent",
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.1",
+        "Framework :: Django :: 3.2",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     extras_require={
         "dev": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-  py{35,36,37}-cpython
+  py{36,37,38,39}-cpython-django{22,31,32}
   flake8
   migrations
 
@@ -10,6 +10,9 @@ deps=
            pytest-cov
            pytest-django
   flake8: flake8
+  django22: django>=2.2,<3
+  django31: django>=3.1,<3.2
+  django32: django>=3.2
 commands=
   py.test {posargs}
 setenv=


### PR DESCRIPTION
- Run tests on supported versions of Python and Django
- Drop warning message on django>=3.2

```
RemovedInDjango41Warning: 'django_dramatiq' defines default_app_config = 'django_dramatiq.apps.DjangoDramatiqConfig'. Django now detects this configuration automatically. You can remove default_app_config.
    app_config = AppConfig.create(entry)
```