### PR TITLE
rundramatiq: align default thread count with dramatiq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+
+- The default thread count is now 8 instead of the CPU count.
+  ([@Ecno92], [#115])
+
 ### Added
 
 - The `DRAMATIQ_AUTODISCOVER_MODULES` setting. ([@thebjorn], [#97], [#98], [#99])

--- a/django_dramatiq/management/commands/rundramatiq.py
+++ b/django_dramatiq/management/commands/rundramatiq.py
@@ -46,9 +46,9 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--threads", "-t",
-            default=CPU_COUNT,
+            default=8,
             type=int,
-            help="The number of threads per process to use (default: %d)." % CPU_COUNT,
+            help="The number of threads per process to use (default: 8).",
         )
         parser.add_argument(
             "--path", "-P",

--- a/tests/test_rundramatiq_command.py
+++ b/tests/test_rundramatiq_command.py
@@ -44,7 +44,7 @@ def test_rundramatiq_can_run_dramatiq(execvp_mock):
     )
 
     execvp_mock.assert_called_once_with(expected_exec_path, [
-        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", "8",
         "--worker-shutdown-timeout", "600000",
         "django_dramatiq.setup",
         "django_dramatiq.tasks",
@@ -74,7 +74,7 @@ def test_rundramatiq_can_run_dramatiq_reload(execvp_mock):
     )
 
     execvp_mock.assert_called_once_with(expected_exec_path, [
-        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", "8",
         "--worker-shutdown-timeout", "600000",
         "--watch", ".",
         "django_dramatiq.setup",
@@ -105,7 +105,7 @@ def test_rundramatiq_can_run_dramatiq_with_polling(execvp_mock):
     )
 
     execvp_mock.assert_called_once_with(expected_exec_path, [
-        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", "8",
         "--worker-shutdown-timeout", "600000",
         "--watch", ".",
         "--watch-use-polling",
@@ -137,7 +137,7 @@ def test_rundramatiq_can_run_dramatiq_with_only_some_queues(execvp_mock):
     )
 
     execvp_mock.assert_called_once_with(expected_exec_path, [
-        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", "8",
         "--worker-shutdown-timeout", "600000",
         "django_dramatiq.setup",
         "django_dramatiq.tasks",
@@ -168,7 +168,7 @@ def test_rundramatiq_can_run_dramatiq_with_specified_pid_file(execvp_mock):
     )
 
     execvp_mock.assert_called_once_with(expected_exec_path, [
-        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", "8",
         "--worker-shutdown-timeout", "600000",
         "django_dramatiq.setup",
         "django_dramatiq.tasks",
@@ -199,7 +199,7 @@ def test_rundramatiq_can_run_dramatiq_with_specified_log_file(execvp_mock):
     )
 
     execvp_mock.assert_called_once_with(expected_exec_path, [
-        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", "8",
         "--worker-shutdown-timeout", "600000",
         "django_dramatiq.setup",
         "django_dramatiq.tasks",
@@ -246,7 +246,7 @@ def test_rundramatiq_can_ignore_modules(execvp_mock, settings):
     )
 
     execvp_mock.assert_called_once_with(expected_exec_path, [
-        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", "8",
         "--worker-shutdown-timeout", "600000",
         "django_dramatiq.setup",
         "django_dramatiq.tasks",
@@ -273,7 +273,7 @@ def test_rundramatiq_can_fork(execvp_mock, settings):
     )
 
     execvp_mock.assert_called_once_with(expected_exec_path, [
-        expected_exec_name, "--path", ".", "--processes", cores, "--threads", cores,
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", "8",
         "--worker-shutdown-timeout", "600000",
         "--fork-function", "a",
         "--fork-function", "b",


### PR DESCRIPTION
The default amount of threads is 8 in dramatiq.
However in this project it was using the CPU count.
This change sets the thread count by default to 8

Closes: #115

Also updated the Changelog, but did not update the version or anything like that. 
I recommend to do a minor release as deployements might be in trouble in case
they start running at a different thread count after upgrading.