### PR TITLE
docs: Add import path for `delete_old_tasks()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ a good idea to garbage collect that data every once in a while.  You
 can use the `delete_old_tasks` actor to achieve this on a cron:
 
 ``` python
+from django_dramatiq.tasks import delete_old_tasks
+
 delete_old_tasks.send(max_task_age=86400)
 ```
 


### PR DESCRIPTION
## Why? 🤔
I was reading the documentation to understand how to add garbage collection for old tasks in my project and I had to spend a few minutes to find from where to import `delete_old_tasks()`

## What? 🤌🏼
Updated the README with the import path for `delete_old_tasks()`