### PR TITLE
Fix #123 -- init broker configuration before loading other app models

### DIFF
--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -48,7 +48,8 @@ class DjangoDramatiqConfig(AppConfig):
 
     def ready(self):
         if getattr(self, "_is_ready", False):
-            super().ready()
+            return
+        super().ready()
 
         global RATE_LIMITER_BACKEND
         dramatiq.set_encoder(self.select_encoder())

--- a/tests/testapp1/apps.py
+++ b/tests/testapp1/apps.py
@@ -5,4 +5,4 @@ class Testapp1Config(AppConfig):
     name = "tests.testapp1"
 
     def ready(self):
-        from . import tasks
+        from . import tasks  # noqa

--- a/tests/testapp1/apps.py
+++ b/tests/testapp1/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class Testapp1Config(AppConfig):
     name = "tests.testapp1"
+
+    def ready(self):
+        from . import tasks

--- a/tests/testapp1/models.py
+++ b/tests/testapp1/models.py
@@ -1,2 +1,2 @@
 # Quite common use-case when you want to run tasks within models.py code
-from tests.testapp1 import tasks
+from tests.testapp1 import tasks  # noqa

--- a/tests/testapp1/models.py
+++ b/tests/testapp1/models.py
@@ -1,0 +1,2 @@
+# Quite common use-case when you want to run tasks within models.py code
+from tests.testapp1 import tasks


### PR DESCRIPTION
Bug from #123 was introduced in https://github.com/Bogdanp/django_dramatiq/pull/103 where django_dramatiq started benefitting from `AppConfig.ready()` functionality.
There was a research done in https://github.com/Bogdanp/django_dramatiq/issues/100 explaining the underlying issue.

My PR is using the idea from @dnmellen to call `DjangoDramatiqConfig.ready()` during its models import, so earlier than any other custom models code would be imported.
I was trying to come up with a different way, as this one feels tiny bit "hacky", however could not find anything better.
