### PR TITLE
Sync current Python and Django versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,17 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
-        django-version: [ "3.2", "4.0", "4.1" ]
-    name: Test on Python ${{ matrix.python-version }} with Django ${{ matrix.django-version }}
+    name: Test on Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - run: pip install tox
-      - run: tox -e "py${PYTHON_VERSION//[.]/}-cpython-django${DJANGO_VERSION//[.]/}"
+      - run: pip install tox tox-py
+      - run: tox --py current
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}
-          DJANGO_VERSION: ${{ matrix.django-version }}
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9" ]
-        django-version: [ "2.2", "3.1", "3.2" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        django-version: [ "3.2", "4.0", "4.1" ]
     name: Test on Python ${{ matrix.python-version }} with Django ${{ matrix.django-version }}
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Support for Python 3.10 and 3.11
+- Support for Django 4.0 and 4.1
+
+### Dropped
+- Support for Python 3.6
+- Support for Django 2.2 and 3.1
+
 ## [0.11.0] - 2022-06-11
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 ## Requirements
 
-* [Django][django] 2.2+
+* [Python][python] 3.7+
+* [Django][django] 3.2+
 * [Dramatiq][dramatiq] 1.11+
 
 
@@ -337,10 +338,11 @@ Install the dev dependencies with `pip install -e '.[dev]'` and then run `tox`.
 
 ## License
 
-django_dramatiq is licensed under Apache 2.0.  Please see
+django_dramatiq is licensed under Apache 2.0. Please see
 [LICENSE][license] for licensing details.
 
-[django]: http://djangoproject.com/
+[python]: https://www.python.org/
+[django]: https://djangoproject.com/
 [dramatiq]: https://github.com/Bogdanp/dramatiq
 [example]: https://github.com/Bogdanp/django_dramatiq_example
 [license]: https://github.com/Bogdanp/django_dramatiq/blob/master/LICENSE

--- a/django_dramatiq/__init__.py
+++ b/django_dramatiq/__init__.py
@@ -1,6 +1,1 @@
-import django
-
 __version__ = "0.11.0"
-
-if django.VERSION < (3, 2):
-    default_app_config = "django_dramatiq.apps.DjangoDramatiqConfig"

--- a/setup.py
+++ b/setup.py
@@ -37,14 +37,15 @@ setup(
         "Environment :: Web Environment",
         "Operating System :: OS Independent",
         "Framework :: Django",
-        "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.1",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     extras_require={
         "dev": [
@@ -59,6 +60,6 @@ setup(
             "twine",
         ]
     },
-    python_requires=">=3.5",
+    python_requires=">=3.7",
     include_package_data=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
 [tox]
 envlist=
-  py{37,38,39}-cpython-django{22,31,32,40}
+  py37-django{32}
+  py38-django{32,40,41}
+  py39-django{32,40,41}
+  py310-django{32,40,41}
+  py311-django{41}
   flake8
   migrations
 
@@ -10,10 +14,9 @@ deps=
            pytest-cov
            pytest-django
   flake8: flake8
-  django22: django>=2.2,<3
-  django31: django>=3.1,<3.2
   django32: django>=3.2,<4.0
   django40: django>=4.0,<4.1
+  django41: django>=4.1,<4.2
 commands=
   py.test {posargs}
 setenv=


### PR DESCRIPTION
- Added support for Python 3.10 and 3.11
- Added support for Django 4.0 and 4.1
- Dropped support for Python 3.6
- Dropped support for Django 2.2 and 3.1
- Dropped custom app initializer for Django < 3.2

Check https://endoflife.date/python and https://endoflife.date/django for active versions information.
