### PR TITLE
Trigger GitHub Actions on PRs and commits to the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
-on: [push]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Existing action was triggered only on push, which I presume works only for code maintainers.
This PR changes behaviour to also trigger on new pull requests (same logic as we have in [model_bakery](https://github.com/model-bakers/model_bakery/blob/main/.github/workflows/tests.yml))

I also updated job name to better reflect what is it for (for example, later we could also introduce release.yml for automatic PyPI releases from GitHub actions).