### PR TITLE
Fix for #135 -- when using the PickleEncoder

### DIFF
--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -5,6 +5,8 @@ from django.conf import settings
 from django.contrib import admin
 from django.utils import timezone
 from django.utils.safestring import mark_safe
+from django_dramatiq.apps import DjangoDramatiqConfig
+from dramatiq.encoder import JSONEncoder
 
 from .models import Task
 
@@ -35,7 +37,16 @@ class TaskAdmin(admin.ModelAdmin):
         return datetime.fromtimestamp(timestamp, tz=tz)
 
     def message_details(self, instance):
-        message_details = json.dumps(instance.message._asdict(), indent=4)
+        message_dict = instance.message._asdict()
+
+        # make sure we can still get a representation of the
+        # kwargs payload when a non json encoder is in use
+        kwargs_encoder = DjangoDramatiqConfig.select_encoder()
+        if not isinstance(kwargs_encoder, JSONEncoder):
+            for k,v in message_dict['kwargs'].items():
+                message_dict['kwargs'][k] = f"<{v}>"
+
+        message_details = json.dumps(message_dict, indent=4)
         return mark_safe("<pre>%s</pre>" % message_details)
 
     def traceback(self, instance):


### PR DESCRIPTION
When using the PickleEncoder make sure the task view still works by showing a representation of the kwargs which is json serializable
This fixes an issue for me when I wasn't able to see the task details
Each kwarg is simply replaced by a string representation if an encoder other than the JSONEncoder is used