### PR TITLE
Replace `AppConfig.ready` workaround with `__init__`

### DIFF
--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -35,21 +35,8 @@ class DjangoDramatiqConfig(AppConfig):
     name = "django_dramatiq"
     verbose_name = "Django Dramatiq"
 
-    def import_models(self):
-        """
-        Initialize Dramatiq configuration right after Django has loaded its models.
-
-        Django calls `ready()` on all apps only after it has loaded all models.
-        Due to the fact that tasks often imported from models, we need to make sure
-        that Dramatiq is fully configured before that happens.
-        """
-        super().import_models()
-        self.ready()
-
-    def ready(self):
-        if getattr(self, "_is_ready", False):
-            return
-        super().ready()
+    def __init__(self, app_name, app_module):
+        super().__init__(app_name, app_module)
 
         global RATE_LIMITER_BACKEND
         dramatiq.set_encoder(self.select_encoder())
@@ -90,8 +77,6 @@ class DjangoDramatiqConfig(AppConfig):
 
         broker = broker_class(middleware=middleware, **broker_options)
         dramatiq.set_broker(broker)
-
-        self._is_ready = True
 
     @property
     def rate_limiter_backend(self):


### PR DESCRIPTION
Attempt to simplify and not break dramatiq configuration logic.
Because `AppConfig.ready` is being called rather late,
we added workaround to call `ready()` earlier during model import.
However, this adds complexity and can bring unexpected implications
if someone is overwriting `apps.DjangoDramatiqConfig`.
