### PR TITLE
Add GitHub action to release package on PyPI (Fix #132)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: PyPI release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Build dist packages
+        run: python setup.py sdist bdist_wheel
+
+      - name: Upload packages to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
`PYPI_API_TOKEN` needs to be set in GitHub secrets for this action to work.

@Bogdanp may you check this one out at your time and if everything is fine, generate and set a token from PyPI on this repo?

Cheers,
Rust