### PR TITLE
doc: split magic numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ DRAMATIQ_RESULT_BACKEND = {
         "url": "redis://localhost:6379",
     },
     "MIDDLEWARE_OPTIONS": {
-        "result_ttl": 60000
+        "result_ttl": 1000 * 60 * 10
     }
 }
 ```
@@ -229,7 +229,7 @@ can use the `delete_old_tasks` actor to achieve this on a cron:
 ``` python
 from django_dramatiq.tasks import delete_old_tasks
 
-delete_old_tasks.send(max_task_age=86400)
+delete_old_tasks.send(max_task_age=60 * 60 * 24)
 ```
 
 


### PR DESCRIPTION
In dramatiq, `DEFAULT_RESULT_TTL = 600_000` which is documented as the 10 minute default. In django_dramatiq, the example uses `"result_ttl": 60_000` which equates to 1 minute.   Although the example shows a customization and not necessarily the defaults, the duration is better communicated by splitting it up into different units. 

Maybe it's just me, but I wasn't sure which units the durations had to be specified in and had to look at the source code / docs.