### PR TITLE
Store traceback in django admin

### DIFF
--- a/django_dramatiq/middleware.py
+++ b/django_dramatiq/middleware.py
@@ -47,7 +47,12 @@ class AdminMiddleware(Middleware):
 
         if exception is not None:
             status = Task.STATUS_FAILED
-            message.options["traceback"] = traceback.format_exc(limit=30)
+            message.options['traceback'] = ''.join(
+                traceback.format_exception(
+                    exception,
+                    limit=30,
+                )
+            )
         elif status is None:
             status = Task.STATUS_DONE
 

--- a/django_dramatiq/middleware.py
+++ b/django_dramatiq/middleware.py
@@ -1,4 +1,5 @@
 import logging
+import traceback
 
 from django import db
 from dramatiq.middleware import Middleware
@@ -46,6 +47,7 @@ class AdminMiddleware(Middleware):
 
         if exception is not None:
             status = Task.STATUS_FAILED
+            message.options["traceback"] = traceback.format_exc(limit=30)
         elif status is None:
             status = Task.STATUS_DONE
 

--- a/tests/test_admin_middleware.py
+++ b/tests/test_admin_middleware.py
@@ -52,6 +52,7 @@ def test_admin_middleware_keeps_track_of_failed_tasks(transactional_db, broker, 
     task = Task.tasks.get()
     assert task
     assert task.status == Task.STATUS_FAILED
+    assert "RuntimeError" in task.message.options["traceback"]
 
 
 def test_admin_middleware_keeps_track_of_skipped_tasks(transactional_db, broker, worker):


### PR DESCRIPTION
Currently the traceback stored in django admin relies on RetriesMiddleware, if retries is set to 0 or it is disabled, traceback is not stored in django admin, AdminMiddleware should always set traceback without depending on RetriesMiddleware.