### PR TITLE
Fix to asdict used in Dramatiq Message

### DIFF
--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -35,7 +35,7 @@ class TaskAdmin(admin.ModelAdmin):
         return datetime.fromtimestamp(timestamp, tz=tz)
 
     def message_details(self, instance):
-        message_details = json.dumps(instance.message._asdict(), indent=4)
+        message_details = json.dumps(instance.message.asdict(), indent=4)
         return mark_safe("<pre>%s</pre>" % message_details)
 
     def traceback(self, instance):


### PR DESCRIPTION
Probably a change occurred in Message but was not updated here.
Without this fix the message details field in admin stays empty.

Tested with:
dramatiq: 1.14.1
django_dramatiq: 0.11.2