### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
     name: Test on Python ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.x"
           architecture: x64
       - run: pip install tox
       - run: tox -e flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Dropped
+- Support for Python 3.7
 
 ## [0.11.2] - 2022-11-18
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-* [Python][python] 3.7+
+* [Python][python] 3.8+
 * [Django][django] 3.2+
 * [Dramatiq][dramatiq] 1.11+
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -60,6 +59,6 @@ setup(
             "twine",
         ]
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     include_package_data=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist=
-  py37-django{32}
   py38-django{32,40,41}
   py39-django{32,40,41}
   py310-django{32,40,41}


### PR DESCRIPTION
It reached end-of-life:
https://devguide.python.org/versions/
