### PR TITLE
Drop Django 4.0 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "django_dramatiq.migrations",
     ],
     install_requires=[
-        "django>=2.2",
+        "django>=3.2",
         "dramatiq>=1.11",
     ],
     classifiers=[
@@ -38,7 +38,6 @@ setup(
         "Operating System :: OS Independent",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist=
-  py38-django{32,40,41}
-  py39-django{32,40,41}
-  py310-django{32,40,41}
+  py{38,39,310}-django{32,41}
   py311-django{41}
   flake8
   migrations
@@ -14,7 +12,6 @@ deps=
            pytest-django
   flake8: flake8
   django32: django>=3.2,<4.0
-  django40: django>=4.0,<4.1
   django41: django>=4.1,<4.2
 commands=
   py.test {posargs}


### PR DESCRIPTION
It reached end-of-life:
https://www.djangoproject.com/download/
