### PR TITLE
Fix CustomDjangoDramatiqConfig example

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,6 @@ class CustomDjangoDramatiqConfig(DjangoDramatiqConfig):
     @classmethod
     def middleware_groupcallbacks_kwargs(cls):
         return {"rate_limiter_backend": cls.get_rate_limiter_backend()}
-
-
-CustomDjangoDramatiqConfig.initialize()
 ```
 
 Notice the naming convention, to provide arguments to


### PR DESCRIPTION
The `initialize` method does not exist and Django automatically loads apps. Simply adding the app `INSTALLED_APPS` is all there is to it. Tested with `django==4.2.11`. Fixes #157.