### PR TITLE
Use python -m build for building dist of package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Install dependencies
-        run: python -m pip install --upgrade pip setuptools wheel
+        run: python -m pip install --upgrade pip build
 
       - name: Build dist packages
-        run: python setup.py sdist bdist_wheel
+        run: python -m build
 
       - name: Upload packages to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Usage of sdist and bdist_wheel commands are deprecated and we should use build instead. 

https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#is-setup-py-deprecated