### PR TITLE
Remove bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,0 @@
-[bumpversion]
-current_version = 0.12.0
-message = chore: bump version {current_version} → {new_version}
-commit = True
-tag = True
-
-[bumpversion:file:django_dramatiq/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     ],
     extras_require={
         "dev": [
-            "bumpversion",
             "flake8",
             "flake8-quotes",
             "isort",


### PR DESCRIPTION
I would like to remove `bumpversion` as a dependency as the project is ~questionably~ (un)maintained  (see below) and we would need to migrate to a fork-of-the-fork of the project if we want to continue using it. 

However, I question the need for it at all as we only bump the __init__ file and our release process is quite smooth with using the release functionality on github ([recently documented here](https://github.com/Bogdanp/django_dramatiq/blob/master/CONTRIBUTING.md#deploying-a-new-version)).

Any thoughts on this @amureki @Bogdanp ? FYI, I see this is still a dependency on [Dramatiq](https://github.com/Bogdanp/dramatiq/blob/master/setup.py#L84)

Bumpversion status:
- original project (https://github.com/peritus/bumpversion) redirects to -->
- unmaintained fork (https://github.com/c4urself/bump2version/#bump2version) redirects to -->
- maintained fork (https://github.com/callowayproject/bump-my-version)