### PR TITLE
Fixes #188: when using the PickleEncoder, fix task view for args

### DIFF
--- a/django_dramatiq/admin.py
+++ b/django_dramatiq/admin.py
@@ -39,9 +39,11 @@ class TaskAdmin(admin.ModelAdmin):
         message_dict = instance.message._asdict()
 
         # make sure we can still get a representation of the
-        # kwargs payload when a non json encoder is in use
-        kwargs_encoder = DjangoDramatiqConfig.select_encoder()
-        if not isinstance(kwargs_encoder, JSONEncoder):
+        # args + kwargs payload when a non json encoder is in use
+        dramatiq_encoder = DjangoDramatiqConfig.select_encoder()
+        if not isinstance(dramatiq_encoder, JSONEncoder):
+            for k, v in message_dict["args"].items():
+                message_dict["args"][k] = f"<{v}>"
             for k, v in message_dict["kwargs"].items():
                 message_dict["kwargs"][k] = f"<{v}>"
 


### PR DESCRIPTION
Simple fix, just like the one for #136 a long time ago.
This week I came across a very similar issue, but this time for the args instead of the kwargs