### PR TITLE
Allow watch directory to be set via CLI

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@ This file lists the contributors to the `Django Dramatiq` project.
 | [@magraeber](https://github.com/magraeber)                             | magraeber           |
 | [@andrewgy8](https://github.com/andrewgy8)                             | Andrew Graham-Yooll |
 | [@m000](https://github.com/m000)                                       | m000                |
+| [@dbowring](https://github.com/dbowring)                               | Daniel Bowring      |

--- a/django_dramatiq/management/commands/rundramatiq.py
+++ b/django_dramatiq/management/commands/rundramatiq.py
@@ -32,11 +32,18 @@ class Command(BaseCommand):
             dest="skip_logging",
             help="Do not call logging.basicConfig()"
         )
-        parser.add_argument(
+        watch_group = parser.add_mutually_exclusive_group()
+        watch_group.add_argument(
             "--reload",
-            action="store_true",
-            dest="use_watcher",
-            help="Enable autoreload",
+            action="store_const",
+            const=".",
+            dest="watch_dir",
+            help="Enable autoreload. Equivalent to '--watch .'",
+        )
+        watch_group.add_argument(
+            "--watch",
+            dest="watch_dir",
+            help="Reload workers when changes are detected in the given directory",
         )
         parser.add_argument(
             "--reload-use-polling",
@@ -97,11 +104,11 @@ class Command(BaseCommand):
             help="Timeout for worker shutdown, in milliseconds"
         )
 
-    def handle(self, use_watcher, skip_logging, use_polling_watcher, use_gevent, path, processes, threads, verbosity,
+    def handle(self, watch_dir, skip_logging, use_polling_watcher, use_gevent, path, processes, threads, verbosity,
                queues, pid_file, log_file, forks, worker_shutdown_timeout, **options):
         executable_name = "dramatiq-gevent" if use_gevent else "dramatiq"
         executable_path = self._resolve_executable(executable_name)
-        watch_args = ["--watch", "."] if use_watcher else []
+        watch_args = ["--watch", watch_dir] if watch_dir else []
         if watch_args and use_polling_watcher:
             watch_args.append("--watch-use-polling")
 

--- a/tests/test_rundramatiq_command.py
+++ b/tests/test_rundramatiq_command.py
@@ -63,7 +63,7 @@ def test_rundramatiq_can_run_dramatiq_reload(execvp_mock):
     # Given an output buffer
     buff = StringIO()
 
-    # When I call the rundramatiq command with --reload-use-polling
+    # When I call the rundramatiq command with --reload
     call_command("rundramatiq", "--reload", stdout=buff)
 
     # Then execvp should be called with the appropriate arguments
@@ -79,6 +79,38 @@ def test_rundramatiq_can_run_dramatiq_reload(execvp_mock):
         expected_exec_name, "--path", ".", "--processes", cores, "--threads", threads,
         "--worker-shutdown-timeout", "600000",
         "--watch", ".",
+        "django_dramatiq.setup",
+        "django_dramatiq.tasks",
+        "tests.testapp1.tasks",
+        "tests.testapp2.tasks",
+        "tests.testapp3.tasks.other_tasks",
+        "tests.testapp3.tasks.tasks",
+        "tests.testapp3.tasks.utils",
+        "tests.testapp3.tasks.utils.not_a_task",
+    ])
+
+
+@patch("os.execvp")
+def test_rundramatiq_can_run_dramatiq_watch(execvp_mock):
+    # Given an output buffer
+    buff = StringIO()
+
+    # When I call the rundramatiq command with --watch
+    call_command("rundramatiq", "--watch", "/path/to/watch/dir", stdout=buff)
+
+    # Then execvp should be called with the appropriate arguments
+    cores = str(rundramatiq.NPROCS)
+    threads = str(rundramatiq.NTHREADS)
+    expected_exec_name = "dramatiq"
+    expected_exec_path = os.path.join(
+        os.path.dirname(sys.executable),
+        expected_exec_name,
+    )
+
+    execvp_mock.assert_called_once_with(expected_exec_path, [
+        expected_exec_name, "--path", ".", "--processes", cores, "--threads", threads,
+        "--worker-shutdown-timeout", "600000",
+        "--watch", "/path/to/watch/dir",
         "django_dramatiq.setup",
         "django_dramatiq.tasks",
         "tests.testapp1.tasks",


### PR DESCRIPTION
`--reload` always uses the working directory, added `--watch` so that the directory may be set to another value.


E.g.,

```
$ django-admin rundramatiq --reload
````

Would be the same as:

```
$ django-admin rundramatiq --watch .
```

But we can also now watch alternate directories, E.g.,

```
$ cd /home/tasks && django-admin rundramatiq --watch /opt/myapp/src
```

`--reload` is kept as an alias for `--watch .`, so existing users do not need to change anything.


