### PR TITLE
Readme update -`mark_safe` usage in admin views

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,57 @@ class CustomerTestCase(DramatiqTestCase):
 
 ## Advanced Usage
 
+### Security notice: `mark_safe` in admin views
+
+The `TaskAdmin` class uses `mark_safe()` to render task message details
+and tracebacks inside `<pre>` tags. If task arguments or exception
+messages contain untrusted user input, this could allow stored XSS when
+an admin views the task in the Django admin.
+
+This is unlikely to be exploitable in most deployments because the
+Django admin is a trusted environment that is only accessible to staff
+users. However, if your tasks process untrusted input (e.g. webhook
+payloads, user-submitted data) and that input appears in task arguments
+or exception messages, you should override `TaskAdmin` to escape the
+output:
+
+```python
+# In your app's admin.py
+import json
+
+from django.contrib import admin
+from django.utils.html import format_html
+
+from django_dramatiq.admin import TaskAdmin
+from django_dramatiq.apps import DjangoDramatiqConfig
+from django_dramatiq.models import Task
+from dramatiq.encoder import JSONEncoder
+
+admin.site.unregister(Task)
+
+
+@admin.register(Task)
+class SafeTaskAdmin(TaskAdmin):
+    def message_details(self, instance):
+        message_dict = instance.message._asdict()
+
+        dramatiq_encoder = DjangoDramatiqConfig.select_encoder()
+        if not isinstance(dramatiq_encoder, JSONEncoder):
+            for k, v in message_dict["args"].items():
+                message_dict["args"][k] = f"<{v}>"
+            for k, v in message_dict["kwargs"].items():
+                message_dict["kwargs"][k] = f"<{v}>"
+
+        message_details = json.dumps(message_dict, indent=4)
+        return format_html("<pre>{}</pre>", message_details)
+
+    def traceback(self, instance):
+        traceback = instance.message.options.get("traceback", None)
+        if traceback:
+            return format_html("<pre>{}</pre>", traceback)
+        return None
+```
+
 ### Cleaning up old tasks
 
 The `AdminMiddleware` stores task metadata in a relational DB so it's


### PR DESCRIPTION

We received a security report in #214 (attached below) flagging the use of `mark_safe()` in `TaskAdmin` for rendering message details and tracebacks. The concern is that if task arguments or exception messages contain untrusted user input, this could be a stored XSS vector when viewed in the Django admin.

### Assessment

This is a **valid use case for `mark_safe`**. We're rendering structured data inside `<pre>` tags in a trusted admin-only context. The risk is low for most deployments since the Django admin is restricted to staff users. That said, applications that process untrusted input through Dramatiq tasks (e.g. webhook payloads, user-submitted data) could be affected.

### Proposed approach

Rather than changing the library's default behavior, this PR:

1. **Adds a security notice** to the README disclosing the `mark_safe` usage
2. **Provides a workaround** showing how to override `TaskAdmin` with a `SafeTaskAdmin` that uses `format_html()` to auto-escape interpolated values

If this turns out to be a common concern, we can merge the workaround into the codebase as the default behavior in a future release.

WDYT?
[django-dramatiq-security-disclosure.md](https://github.com/user-attachments/files/25340186/django-dramatiq-security-disclosure.md)

