### PR TITLE
Fix middleware import path for Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] -
+### Changed
+- Update dramatiq Prometheus middleware path in docs examples (#217)
+
 ## [0.15.0] - 2025-11-12
 ### Added
 - Support for `--use-spawn` (#199)
@@ -86,7 +90,7 @@ Set number of processes/threads through DRAMATIQ_NPROCS, DRAMATIQ_NTHREADS. ([m0
 - Support for Django 4.0 and 4.1
 
 ### Changed
-- Fixed issue [#123] in deferred `DjangoDramatiqConfig` initialization. 
+- Fixed issue [#123] in deferred `DjangoDramatiqConfig` initialization.
   Dramatiq configuration now happens before loading importing all Django apps models,
   so loaded tasks will use the correct Dramatiq settings. ([@amureki], [#126])
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,7 +3,7 @@
 This file lists the contributors to the `Django Dramatiq` project.
 
 | Username                                                               | Name                |
-| :-------                                                               | :---                |
+|:-----------------------------------------------------------------------|:--------------------|
 | [@rakanalh](https://github.com/rakanalh)                               | Rakan Alhneiti      |
 | [@rpkilby](https://github.com/rpkilby)                                 | Ryan P Kilby        |
 | [@nachopro](https://github.com/nachopro)                               | nachopro            |
@@ -26,3 +26,4 @@ This file lists the contributors to the `Django Dramatiq` project.
 | [@michael-provision](https://github.com/michael-provision)             | michael-provision   |
 | [@antonio-lm-jr](https://github.com/antonio-lm-jr)                     | antonio-lm-jr       |
 | [@ulgens](https://github.com/ulgens)                                   | Ülgen Sarıkavak     |
+| [@scpaes](https://github.com/scpaes)                                   | Samuel Paes         |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ DRAMATIQ_BROKER = {
         "url": "amqp://localhost:5672",
     },
     "MIDDLEWARE": [
-        "dramatiq.middleware.Prometheus",
+        "dramatiq.middleware.prometheus.Prometheus",
         "dramatiq.middleware.AgeLimit",
         "dramatiq.middleware.TimeLimit",
         "dramatiq.middleware.Callbacks",

--- a/django_dramatiq/apps.py
+++ b/django_dramatiq/apps.py
@@ -18,7 +18,7 @@ DEFAULT_BROKER_SETTINGS = {
         "connection_attempts": 5,
     },
     "MIDDLEWARE": [
-        "dramatiq.middleware.Prometheus",
+        "dramatiq.middleware.prometheus.Prometheus",
         "dramatiq.middleware.AgeLimit",
         "dramatiq.middleware.TimeLimit",
         "dramatiq.middleware.Callbacks",

--- a/examples/basic/basic/settings.py
+++ b/examples/basic/basic/settings.py
@@ -127,7 +127,7 @@ DRAMATIQ_BROKER = {
         "url": "redis://localhost:6379",
     },
     "MIDDLEWARE": [
-        "dramatiq.middleware.Prometheus",
+        "dramatiq.middleware.prometheus.Prometheus",
         "dramatiq.middleware.AgeLimit",
         "dramatiq.middleware.TimeLimit",
         "dramatiq.middleware.Callbacks",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,9 @@
 import os
 
 import pytest
+from django.test import override_settings
 
+from django_dramatiq.apps import DEFAULT_BROKER_SETTINGS, DjangoDramatiqConfig
 from django_dramatiq.utils import getenv_int
 
 
@@ -30,3 +32,23 @@ def test_getenv_int(value, default, expected):
             getenv_int(varname, default)
     else:
         assert getenv_int(varname, default) == expected
+
+
+def test_default_broker_uses_supported_prometheus_import_path():
+    assert DEFAULT_BROKER_SETTINGS["MIDDLEWARE"][0] == "dramatiq.middleware.prometheus.Prometheus"
+
+
+@override_settings(
+    DRAMATIQ_BROKER={"BROKER": "dramatiq.brokers.stub.StubBroker", "OPTIONS": {}, "MIDDLEWARE": []},
+    DRAMATIQ_RESULT_BACKEND={"BACKEND": "dramatiq.results.backends.stub.StubBackend"},
+    DRAMATIQ_RATE_LIMITER_BACKEND={"BACKEND": "dramatiq.rate_limits.backends.stub.StubBackend"},
+    DRAMATIQ_TASKS_DATABASE="secondary",
+)
+def test_config_reads_overrides_from_settings():
+    assert DjangoDramatiqConfig.broker_settings()["BROKER"] == "dramatiq.brokers.stub.StubBroker"
+    assert DjangoDramatiqConfig.result_backend_settings()["BACKEND"] == "dramatiq.results.backends.stub.StubBackend"
+    assert (
+        DjangoDramatiqConfig.rate_limiter_backend_settings()["BACKEND"]
+        == "dramatiq.rate_limits.backends.stub.StubBackend"
+    )
+    assert DjangoDramatiqConfig.tasks_database() == "secondary"


### PR DESCRIPTION
This pull request updates the documentation and code examples to use the correct import path for the Prometheus middleware and adds new tests to ensure the correct configuration defaults and override behavior. Closes #217 